### PR TITLE
refactor(sagas,reducers): Do 'fromJS' in reducers

### DIFF
--- a/src/reducers/subreddits.js
+++ b/src/reducers/subreddits.js
@@ -1,29 +1,35 @@
-import { Map, Set } from 'immutable';
+import { Map, Set, fromJS } from 'immutable';
 import { handleActions } from 'redux-actions';
 import { SUBREDDITS, CHILDREN_EXPANDED, THUMBNAIL_EXPANDED } from '../constants';
 
 const subreddits = handleActions({
 
-  [SUBREDDITS.SAVE_DEFAULT]: (state, { payload }) => (
-    state.set('default', payload.subreddits)
-  ),
+  [SUBREDDITS.SAVE_DEFAULT]: (state, { payload }) => {
+    return state.set('default', fromJS(payload.subreddits));
+  },
 
   [SUBREDDITS.SAVE_THREADS]: (state, { payload }) => {
     const { subreddit, threads, filter } = payload;
     const filterSet = filter ? Set.of(filter) : Set();
-    return state.updateIn(['threads', subreddit], indexedUpsert(threads.map(
-      (thread) => thread.set('filters', filterSet)
-    )));
+    return state.updateIn(
+      ['threads', subreddit], indexedUpsert(fromJS(threads).map(
+        (thread) => thread.set('filters', filterSet)
+      ))
+    );
   },
 
   [SUBREDDITS.SAVE_THREAD_COMMENTS]: (state, { payload }) => {
     const { subreddit, thread, comments } = payload;
-    return state.updateIn(['comments', subreddit, thread], indexedUpsert(comments));
+    return state.updateIn(
+      ['comments', subreddit, thread], indexedUpsert(fromJS(comments))
+    );
   },
 
   [SUBREDDITS.SAVE_THREAD_COMMENTS_TO_CACHE]: (state, { payload }) => {
     const { subreddit, thread, comments } = payload;
-    return state.updateIn(['subredditCommentCache', subreddit, thread], indexedUpsert(comments));
+    return state.updateIn(
+      ['subredditCommentCache', subreddit, thread], indexedUpsert(fromJS(comments))
+    );
   },
 
   [SUBREDDITS.TOGGLE_THREAD_COMMENT_EXPAND_CHILDREN]: (state, { payload }) => {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -2,7 +2,6 @@ import { takeEvery } from 'redux-saga';
 import { put } from 'redux-saga/effects';
 import { SUBREDDITS } from '../constants';
 import { expect } from 'chai';
-import { fromJS } from 'immutable';
 import {
   saveDefaultSubreddits,
   saveSubredditThreads,
@@ -26,13 +25,13 @@ export default function* root() {
 function* fetchDefaultSubreddits() {
   const response = yield fetch('/reddit/subreddits');
   const subreddits = yield response.json();
-  yield put(saveDefaultSubreddits(fromJS(subreddits.data.children)));
+  yield put(saveDefaultSubreddits(subreddits.data.children));
 }
 
 function* fetchSubredditThreads({ payload: { subreddit, count, after, filter } }) {
   const response = yield fetch(`/reddit/r/${subreddit}/${filter}?count=${count}&after=${after}`);
   const threads = yield response.json();
-  yield put(saveSubredditThreads(subreddit, fromJS(threads.data.children), filter));
+  yield put(saveSubredditThreads(subreddit, threads.data.children, filter));
   yield put(saveSubredditLastFetchedThreadName(subreddit, last(threads.data.children).data.name, filter));
 }
 
@@ -40,8 +39,8 @@ function* fetchSubredditThreadComments({ payload: { subreddit, thread } }) {
   const response = yield fetch(`/reddit/r/${subreddit}/comments/${thread}`);
   const comments = yield response.json();
   expect(comments).to.have.length(2); // first item is the thread
-  yield put(saveSubredditThreads(subreddit, fromJS(comments[0].data.children), null));
-  yield put(saveSubredditThreadComments(subreddit, thread, fromJS(comments[1].data.children)));
+  yield put(saveSubredditThreads(subreddit, comments[0].data.children, null));
+  yield put(saveSubredditThreadComments(subreddit, thread, comments[1].data.children));
 }
 
 function fetchMoreComments(linkId, children) {
@@ -58,10 +57,10 @@ function fetchMoreComments(linkId, children) {
 
 function* fetchSubredditThreadMoreComments({ payload: { linkId, children, subreddit, thread } }) {
   const moreChildren = yield fetchMoreComments(linkId, children);
-  yield put(saveSubredditThreadCommentsToCache(subreddit, thread, fromJS(createCommentTree(moreChildren))));
+  yield put(saveSubredditThreadCommentsToCache(subreddit, thread, createCommentTree(moreChildren)));
 }
 
 function* fetchSubredditThreadMoreRootComments({ payload: { linkId, children, subreddit, thread } }) {
   const moreChildren = yield fetchMoreComments(linkId, children);
-  yield put(saveSubredditThreadComments(subreddit, thread, fromJS(createCommentTree(moreChildren))));
+  yield put(saveSubredditThreadComments(subreddit, thread, createCommentTree(moreChildren)));
 }


### PR DESCRIPTION
Actions should be serializable, so it isn't a good idea to convert the payload to Immutable objects in the sagas. Moving that conversion to the reducers. 
